### PR TITLE
Add a placeholder

### DIFF
--- a/src/Koans/AboutComparisonOperators.elm
+++ b/src/Koans/AboutComparisonOperators.elm
@@ -12,7 +12,7 @@ testSuite =
         (assert (1 == xNum))
     , test
         "/= tests for inequality"
-        (assert (1 /= 1))
+        (assert (-1 /= xNum))
     , test
         "< tests for less than"
         (assert (1 < xNum))


### PR DESCRIPTION
Is this intentional?

``` elm
"/= tests for inequality"
        (assert (1 /= 1))
```

Shouldn't it be `(assert (1 /= xNum))`?
