### PR TITLE
Rename AboutAsserts to AboutExpects

### DIFF
--- a/src/Koans.elm
+++ b/src/Koans.elm
@@ -1,7 +1,7 @@
 module Main exposing (main)
 
 import AboutArrays
-import AboutAsserts
+import AboutExpects
 import AboutComparisonOperators
 import AboutDates
 import AboutDictionaries
@@ -27,7 +27,7 @@ import Test.Runner.Html exposing (run)
 main =
     run <|
         describe "The Elm Koans"
-            [ AboutAsserts.testSuite
+            [ AboutExpects.testSuite
             , AboutLiterals.testSuite
             , AboutComparisonOperators.testSuite
             , AboutLogicalOperators.testSuite

--- a/src/Koans/AboutExpects.elm
+++ b/src/Koans/AboutExpects.elm
@@ -1,4 +1,4 @@
-module AboutAsserts exposing (testSuite)
+module AboutExpects exposing (testSuite)
 
 import Expect
 import Test exposing (describe, test)
@@ -7,10 +7,10 @@ import TestHelpers exposing (..)
 
 testSuite =
     describe "About Expects"
-        [ test "assert tests for a true value" <|
+        [ test "Expect.true tests for a true value" <|
             \() -> Expect.true "Should be True" xBool
-        , test "assertEqual tests for equality" <|
+        , test "Expect.equal tests for equality" <|
             \() -> Expect.equal True xBool
-        , test "assertNotEqual tests for inequality" <|
+        , test "Expect.notEqual tests for inequality" <|
             \() -> Expect.notEqual False xBool
         ]

--- a/src/KoansNode.elm
+++ b/src/KoansNode.elm
@@ -1,7 +1,7 @@
 port module Main exposing (main)
 
 import AboutArrays
-import AboutAsserts
+import AboutExpects
 import AboutComparisonOperators
 import AboutDates
 import AboutDictionaries
@@ -28,7 +28,7 @@ import Test.Runner.Node exposing (run)
 main =
     run emit <|
         describe "The Elm Koans"
-            [ AboutAsserts.testSuite
+            [ AboutExpects.testSuite
             , AboutLiterals.testSuite
             , AboutComparisonOperators.testSuite
             , AboutLogicalOperators.testSuite


### PR DESCRIPTION
When starting the Koans it was hard to find the correct file because of naming inconsistencies
This commit:
- Renames AboutAsserts file and module to AboutExpects
- Anywhere an assert method was referenced reference expects instead
