### PR TITLE
Improve usability of the Koans

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM codesimple/elm:0.18
+
+WORKDIR /app
+
+EXPOSE 8000
+

--- a/Main.elm
+++ b/Main.elm
@@ -91,6 +91,7 @@ view model =
             ]
         ]
         [ viewHeader (floatLength model.upcoming) (floatLength model.seen)
+        , span [] [text "elm reactor does not hot reload"]
         , viewRunner model.final model.seen
         ]
 

--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,5 @@ build:
 	docker-compose build
 
 serve: down build
+	docker-compose run --service-ports --rm elm package install -y
 	docker-compose run --service-ports --rm elm reactor --address=0.0.0.0

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+down:
+	docker-compose down
+
+build:
+	docker-compose build
+
+serve: down build
+	docker-compose run --service-ports --rm elm reactor --address=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -1,16 +1,12 @@
 # Elm Koans
 
+## Prerequisites
+
+* Docker + docker-compose
+
 ## Instructions
-* Get [Elm](http://elm-lang.org/install) version 0.18
-  * Make sure you have at least version 0.18.6 with `elm-test --version`
 * Clone this repo
-* Run the tests
-  * **In the browser**
-    * `elm reactor`
-    * Visit http://localhost:8000/Main.elm
-  * **Using Node**
-    * `npm install -g elm-test`
-    * `elm-test`
-      * Note this will produce a LOT of output, so you'll probably want to `elm-test | head -n20` to just see the first couple failing tests
+* `$ make serve`
+* open http://localhost:8000/Main.elm
 * Use any editor to change the source files, refresh the browser page, and make the tests pass
   * Placeholder values are denoted as `x____replace me____x` and will need to be replaced to make the tests pass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  elm:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./:/app
+    privileged: true


### PR DESCRIPTION
# Motivation

* Get koans into a state where programmers can quickly jump into them during a workshop environment (where messing around with installation is not desirable).
* Provide hints around hot-reloading not being present as this is a common feature of koan repos
* Remove elm-test as an option since it can confuse rather than assist.

We use privileged on the docker container to workaround SELinux issues.

Download packages outside of reactor (saw an issue that required 2 refreshes on some machines).